### PR TITLE
Deleted duplicated code and fixed compile warnings.

### DIFF
--- a/src/keilhexfile.cpp
+++ b/src/keilhexfile.cpp
@@ -1,5 +1,7 @@
 /* Used to eliminate warnings from windows. Will make no harm in Linux. */
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <fstream>
 #include <sstream>
@@ -637,14 +639,14 @@ void KeilHexFile::find_contiguous(uint32_t address_offset,
         bytes_available = 0;
         return;
     }
-    
+
     do
     {
         result_len += len;
         find((result_address + result_len), addr, len);
     }
     while ((0 != len) && (addr == (result_address + result_len)));
-    
+
     bytes_available = result_len;
 }
 
@@ -665,14 +667,14 @@ void KeilHexFile::find_contiguous_max(uint32_t address_offset,
         bytes_available = 0;
         return;
     }
-    
+
     do
     {
         result_len += len;
         find((result_address + result_len), addr, len);
     }
     while ((0 != len) && (addr == (result_address + result_len)));
-    
+
     bytes_available = result_len;
 
     if (bytes_available > bytes_max){

--- a/src/nrfjprogjs.cpp
+++ b/src/nrfjprogjs.cpp
@@ -498,7 +498,7 @@ NAN_METHOD(DebugProbe::Program)
     {
         if (Utility::Has(filenameObject, "filecontent"))
         {
-            baton->filecontent = ConversionUtility::getNativeBool(Utility::Get(filenameObject, "filecontent"));
+            baton->filecontent = ConversionUtility::getBool(Utility::Get(filenameObject, "filecontent"));
         }
         else
         {

--- a/src/platform/osfiles_win32.cpp
+++ b/src/platform/osfiles_win32.cpp
@@ -1,5 +1,6 @@
-
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "Shlwapi.h"
 #include <windows.h>
@@ -21,7 +22,7 @@ bool OSFilesExists(char * path)
 #define MAX_KEY_LENGTH 1000
 #define MAX_VALUE_NAME 1000
 
-NrfjprogErrorCodesType OSFilesFindDll(char * dll_path, int dll_path_len)
+NrfjprogErrorCodesType OSFilesFindDllByHKey(const HKEY rootKey, char * dll_path, int dll_path_len)
 {
     HKEY key;
     HKEY innerKey;
@@ -30,7 +31,7 @@ NrfjprogErrorCodesType OSFilesFindDll(char * dll_path, int dll_path_len)
     DWORD install_path_size = sizeof(install_path);
 
     /* Search for JLinkARM in the Local Machine Key.  */
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, "Software\\Nordic Semiconductor\\nrfjprog", 0, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS, &key) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(rootKey, "Software\\Nordic Semiconductor\\nrfjprog", 0, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS, &key) == ERROR_SUCCESS)
     {
         TCHAR    achKey[MAX_KEY_LENGTH];   // buffer for subkey name
         DWORD    cbName;                   // size of name string
@@ -47,7 +48,6 @@ NrfjprogErrorCodesType OSFilesFindDll(char * dll_path, int dll_path_len)
 
         DWORD retCode;
 
-        TCHAR  achValue[MAX_VALUE_NAME];
         DWORD cchValue = MAX_VALUE_NAME;
 
         retCode = RegQueryInfoKey(
@@ -100,76 +100,19 @@ NrfjprogErrorCodesType OSFilesFindDll(char * dll_path, int dll_path_len)
     }
 
     /* Search for JLinkARM in the Current User Key.  */
-    if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\Nordic Semiconductor\\nrfjprog", 0, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS, &key) == ERROR_SUCCESS)
-    {
-        TCHAR    achKey[MAX_KEY_LENGTH];   // buffer for subkey name
-        DWORD    cbName;                   // size of name string
-        TCHAR    achClass[MAX_PATH] = TEXT("");  // buffer for class name
-        DWORD    cchClassName = MAX_PATH;  // size of class string
-        DWORD    cSubKeys = 0;               // number of subkeys
-        DWORD    cbMaxSubKey;              // longest subkey size
-        DWORD    cchMaxClass;              // longest class string
-        DWORD    cValues;              // number of values for key
-        DWORD    cchMaxValue;          // longest value name
-        DWORD    cbMaxValueData;       // longest value data
-        DWORD    cbSecurityDescriptor; // size of security descriptor
-        FILETIME ftLastWriteTime;      // last write time
-
-        DWORD retCode;
-
-        TCHAR  achValue[MAX_VALUE_NAME];
-        DWORD cchValue = MAX_VALUE_NAME;
-
-        retCode = RegQueryInfoKey(
-            key,                    // key handle
-            achClass,                // buffer for class name
-            &cchClassName,           // size of class string
-            NULL,                    // reserved
-            &cSubKeys,               // number of subkeys
-            &cbMaxSubKey,            // longest subkey size
-            &cchMaxClass,            // longest class string
-            &cValues,                // number of values for this key
-            &cchMaxValue,            // longest value name
-            &cbMaxValueData,         // longest value data
-            &cbSecurityDescriptor,   // security descriptor
-            &ftLastWriteTime);       // last write time
-
-        // Enumerate the subkeys, until RegEnumKeyEx fails.
-
-        if (cSubKeys)
-        {
-            cbName = MAX_KEY_LENGTH;
-            retCode = RegEnumKeyEx(key,
-                                   cSubKeys - 1,
-                                   achKey,
-                                   &cbName,
-                                   NULL,
-                                   NULL,
-                                   NULL,
-                                   &ftLastWriteTime);
-            RegOpenKeyEx(key, achKey, 0, KEY_QUERY_VALUE, &innerKey);
-        }
-
-        /* If it is found, read the install path. */
-        if (RegQueryValueEx(innerKey, "InstallPath", NULL, NULL, (LPBYTE)&install_path, &install_path_size) == ERROR_SUCCESS)
-        {
-            /* Copy, check it exists and return if it does. */
-            strncpy(dll_path, install_path, dll_path_len);
-            strncat(dll_path, "nrfjprog.dll", dll_path_len - strlen(dll_path) - 1);
-            RegCloseKey(innerKey);
-            RegCloseKey(key);
-            if (OSFilesExists(dll_path))
-            {
-                return Success;
-            }
-        }
-
-        /* In case we did not obtain the path, for whatever reason, we close the key. */
-        RegCloseKey(innerKey);
-        RegCloseKey(key);
-    }
 
     return NrfjprogDllNotFoundError;
+}
+
+NrfjprogErrorCodesType OSFilesFindDll(char * dll_path, int dll_path_len)
+{
+    NrfjprogErrorCodesType retCode = OSFilesFindDllByHKey(HKEY_LOCAL_MACHINE, dll_path, dll_path_len);
+
+    if (retCode != Success) {
+        retCode = OSFilesFindDllByHKey(HKEY_CURRENT_USER, dll_path, dll_path_len);
+    }
+
+    return retCode;
 }
 
 NrfjprogErrorCodesType OSFilesFindJLink(char * jlink_path, int jlink_path_len)


### PR DESCRIPTION
Duplicated code was quite long and only depended on HKEY to look up windows registry, so single lookup is separated in its own function which is called by HKEY.

Other mods are fixing redefines and unnecessary bool->uint8_t->bool conversion.