### PR TITLE
Write some jsdoc docstrings

### DIFF
--- a/doc/api.js
+++ b/doc/api.js
@@ -150,7 +150,7 @@
  *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
- * @property {boolean} qspi_erase_mode=nrfjprogjs.ERASE_NONE
+ * @property {integer} qspi_erase_mode=nrfjprogjs.ERASE_NONE
  *    How much of the QSPI memory should be erased. Value must be one of:<br/>
  *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
  *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
@@ -162,15 +162,15 @@
 /**
  * Erase flags to be used when sending a program to the device.
  * @typedef EraseOptions
- * @property {boolean} erase_mode
+ * @property {integer} erase_mode
  *    How much of the memory should be erased. Value must be one of:<br/>
  *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
  *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
- * @property {boolean} start_address
+ * @property {integer} start_address
  *    Start erasing from this address. Only relevant when using <tt>ERASE_PAGES</tt> or <tt>ERASE_PAGES_INCLUDING_UICR</tt> modes.
- * @property {boolean} end_address
+ * @property {integer} end_address
  *    Erasing up to this address. Only relevant when using <tt>ERASE_PAGES</tt> or <tt>ERASE_PAGES_INCLUDING_UICR</tt> modes.
  */
 

--- a/doc/api.js
+++ b/doc/api.js
@@ -9,18 +9,18 @@
 
 /**
  *
- * The <tt>nrfjprogjs</tt> module exposes the functionality to the
+ * The <tt>pc-nrfjprog-js</tt> module exposes the functionality to the
  * nRF5x Command-line tools
  * to your nodeJS programs.
  *
  * @example
- * let nrfjprogjs = require('nrfjprogjs');
+ * let nrfjprogjs = require('pc-nrfjprog-js');
  *
  * nrfjprogjs.getConnectedDevices(function(err, devices) {
  *     console.log('There are ' + devices.length + ' nRF devices connected.');
- * })
+ * });
  *
- * @module nrfjprogjs
+ * @module pc-nrfjprog-js
  */
 
 /**
@@ -130,7 +130,7 @@
  * @typedef SerialNumberAndDeviceInformation
  *
  * @property {string} serialNumber
- * @property {module:nrfjprogjs~DeviceInformation} deviceInfo
+ * @property {module:pc-nrfjprog-js~DeviceInformation} deviceInfo
  */
 
 /**
@@ -184,7 +184,7 @@
  * } );
  *
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, {@link module:nrfjprogjs~Version|Version}).
+ *   It shall expect two parameters: ({@link module:pc-nrfjprog-js~Error|Error}, {@link module:pc-nrfjprog-js~Version|Version}).
  */
 export function getDllVersion() {}
 
@@ -205,7 +205,7 @@ export function getDllVersion() {}
  * } );
  *
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, Array of {@link module:nrfjprogjs~SerialNumberAndDeviceInformation|SerialNumberAndDeviceInformation}).
+ *   It shall expect two parameters: ({@link module:pc-nrfjprog-js~Error|Error}, Array of {@link module:pc-nrfjprog-js~SerialNumberAndDeviceInformation|SerialNumberAndDeviceInformation}).
  */
 export function getConnectedDevices(callback) {}
 
@@ -222,7 +222,7 @@ export function getConnectedDevices(callback) {}
  *
  * @param {integer} serialNumber The serial number of the device to query
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, {@link module:nrfjprogjs~DeviceInformation|DeviceInformation}).
+ *   It shall expect two parameters: ({@link module:pc-nrfjprog-js~Error|Error}, {@link module:pc-nrfjprog-js~DeviceInformation|DeviceInformation}).
  */
 export function getDeviceInfo(serialNumber, callback) {}
 
@@ -246,11 +246,11 @@ export function getDeviceInfo(serialNumber, callback) {}
  *      console.log('The first 16 bytes of memory look like: ' + data.join(','));
  * } );
  *
- * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} serialNumber The serial number of the device to read memory from
  * @param {integer} address The start address of the block of memory to be read
  * @param {integer} length The amount of bytes to be read
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, Array of integers).
+ *   It shall expect two parameters: ({@link module:pc-nrfjprog-js~Error|Error}, Array of integers).
  */
 export function read(serialNumber, address, length, callback) {}
 
@@ -273,10 +273,10 @@ export function read(serialNumber, address, length, callback) {}
  *      console.log('The first word of memory looks like: ' + data);
  * } );
  *
- * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} serialNumber The serial number of the device to read memory from
  * @param {integer} address The address of the word to be read
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, integer).
+ *   It shall expect two parameters: ({@link module:pc-nrfjprog-js~Error|Error}, integer).
  */
 export function readU32(serialNumber, address, callback) {}
 
@@ -293,11 +293,11 @@ export function readU32(serialNumber, address, callback) {}
  *      if (err) throw err;
  * } );
  *
- * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} serialNumber The serial number of the device to program
  * @param {string} filename Either the filename of the <tt>.hex</tt> file containing the program, or the contents of such a file.
- * @param {module:nrfjprogjs~ProgramOptions} options A plain object containing options about how to push the program.
+ * @param {module:pc-nrfjprog-js~ProgramOptions} options A plain object containing options about how to push the program.
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function program(serialNumber, filename, options, callback) {}
 
@@ -318,11 +318,11 @@ export function readToFile(serialNumber, filename, options) {}
  *      if (err) throw err;
  * } );
  *
- * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} serialNumber The serial number of the device
  * @param {string} filename The filename of the <tt>.hex</tt> file containing the program.
  * @param {Object} options={} Reserved for future use.
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function verify(serialNumber, filename, callback) {}
 
@@ -334,12 +334,12 @@ export function verify(serialNumber, filename, callback) {}
  *
  * This is the same functionality as running "<tt>nrfjprog --erasepage</tt>" in the command-line tools.<br/>
  *
- * Will not erase a locked device. To erase a locked device, use {@link module:nrfjprogjs~recover|recover}
+ * Will not erase a locked device. To erase a locked device, use {@link module:pc-nrfjprog-js~recover|recover}
  *
- * @param {integer} serialNumber The serial number of the device to query
- * @param {module:nrfjprogjs~EraseOptions} options Options on how to erase the device memory
+ * @param {integer} serialNumber The serial number of the device
+ * @param {module:pc-nrfjprog-js~EraseOptions} options Options on how to erase the device memory
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function erase(serialNumber, options, callback) {}
 
@@ -354,12 +354,12 @@ export function erase(serialNumber, options, callback) {}
  *
  * This is the same functionality as running "<tt>nrfjprog --recover</tt>" in the command-line tools.
  *
- * @param {integer} serialNumber The serial number of the device to query
- * @param {module:nrfjprogjs~EraseOptions} filename The filename of the <tt>.hex</tt> file containing the program.
+ * @param {integer} serialNumber The serial number of the device to recover
+ * @param {module:pc-nrfjprog-js~EraseOptions} options Options on how to perform the memory recovery
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
-export function recover(serialNumber, filename, callback) {}
+export function recover(serialNumber, options, callback) {}
 
 
 // TODO: Check that this equates to "--memwr" and not to "--ramwr"
@@ -372,11 +372,11 @@ export function recover(serialNumber, filename, callback) {}
  * most likely fail.
  * <br/>
  *
- * @param {integer} serialNumber The serial number of the device to query
- * @param {integer} address The filename of the <tt>.hex</tt> file containing the program.
+ * @param {integer} serialNumber The serial number of the device to write memory to
+ * @param {integer} address The start address of the block of memory to be written
  * @param {Array.integer} data Array of byte values to be written
- * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ * @param {Function} callback A callback function to handle the async response
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function write(serialNumber, address, data, callback) {}
 
@@ -391,11 +391,11 @@ export function write(serialNumber, address, data, callback) {}
  * or a {@link https://nodejs.org/api/buffer.html|Buffer}.
  * <br/>
  *
- * @param {integer} serialNumber The serial number of the device to query
- * @param {integer} address The filename of the <tt>.hex</tt> file containing the program.
- * @param {integer} data Array of byte values to be written
+ * @param {integer} serialNumber The serial number of the device to write memory to
+ * @param {integer} address Address of the memory word to be written
+ * @param {integer} data Value to be written
  * @param {Function} callback A callback function to handle the async response.
- *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function writeU32(serialNumber, address, data, callback) {}
 

--- a/doc/api.js
+++ b/doc/api.js
@@ -150,7 +150,7 @@
  *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
  *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
- * @property {boolean} qspi_erase_mose=nrfjprogjs.ERASE_NONE
+ * @property {boolean} qspi_erase_mode=nrfjprogjs.ERASE_NONE
  *    How much of the QSPI memory should be erased. Value must be one of:<br/>
  *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
  *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
@@ -398,10 +398,3 @@ export function write(serialNumber, address, data, callback) {}
  *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
  */
 export function writeU32(serialNumber, address, data, callback) {}
-
-
-
-
-
-
-

--- a/doc/api.js
+++ b/doc/api.js
@@ -84,7 +84,12 @@
  */
 
 /**
- * Represents information of an individual device
+ * Represents information of an individual device.
+ *
+ * The fields in this data structure about non-volatile memory, RAM, UICR and QSPI can also
+ * be found in the product specifications available
+ * at http://infocenter.nordicsemi.com, under the "Memory" section of each product model.
+ *
  * @typedef DeviceInformation
  *
  * @property {integer} family
@@ -113,23 +118,32 @@
  *    <tt>nrfjprogjs.NRF52832_xxAB_FUTURE</tt><br/>
  *    <tt>nrfjprogjs.NRF51801_xxAB_REV3</tt><br/>
  *
- * @property {integer} codeAddress
- * @property {integer} codePageSize
- * @property {integer} codeSize
+ * @property {integer} codeAddress  Memory address for the start of the non-volatile (flash) memory block.
+ *   Typically <tt>0x0000 0000</tt>.
+ * @property {integer} codePageSize Size of each page of non-volatile (flash) memory.
+ * @property {integer} codeSize     Total size of the non-volatile (flash) memory
  *
- * @property {integer} uicrAddress
- * @property {integer} infoPageSize
+ * @property {integer} uicrAddress  Memory address for the start of the UICR
+ *   (User Information Configuration Registers). Typically <tt>0x1000 1000</tt>.
+ * @property {integer} infoPageSize Size of the FICR/UICR. Typically 4KiB.
  *
- * @property {boolean} codeRamPresent
- * @property {integer} codeRamAddress
- * @property {integer} dataRamAddress
- * @property {integer} ramSize
+ * @property {integer} dataRamAddress Memory address for the start of the volatile RAM.
+ *   Typically <tt>0x2000 0000</tt>, in the SRAM memory region.
+ * @property {integer} ramSize        Size of the volatile RAM, in bytes.
+ * @property {boolean} codeRamPresent Whether the volatile RAM is also mapped to a executable memory region or not.
+ * @property {integer} codeRamAddress Memory address for the volatile RAM, in the code memory region.
+ *   When <tt>codeRamPresent</tt> is true, both <tt>codeRamAddress</tt> and
+ *   <tt>dataRamAddress</tt> point to the same volatile RAM, but the hardware
+ *   uses a different data bus in each case.
  *
- * @property {boolean} qspiPresent
- * @property {integer} xipAddress
- * @property {integer} xipSize
+ * @property {boolean} qspiPresent  Whether QSPI (Quad Serial Peripheral Interface) is present or not.
+ * @property {integer} xipAddress   When <tt>qspiPresent</tt> is true, the memory address for the
+ *   XIP (eXecute In Place) feature. This memory address maps to the external flash
+ *   memory connected through QSPI.
+ * @property {integer} xipSize      Size of the XIP memory region.
  *
- * @property {integer} pinResetPin
+ * @property {integer} pinResetPin  Which pin acts as the reset pin. e.g. a value of <tt>21</tt>
+ *   means that the pin marked as "P0.21" acts as the reset pin.
  */
 
 /**

--- a/doc/api.js
+++ b/doc/api.js
@@ -264,6 +264,10 @@ export function getDeviceInfo(serialNumber, callback) {}
  * from 0 to 255).
  * <br/>
  *
+ * The read operation happens without verifying that the addresses are accessible or
+ * even exist. Note that if the target address is in unpowered RAM, the operation will fail.
+ * <br/>
+ *
  * Please note that the data is an array of numbers - it is NOT a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array|UInt8Array},
  * and it is NOT a {@link https://nodejs.org/api/buffer.html|Buffer}.
  * <br/>
@@ -289,6 +293,11 @@ export function read(serialNumber, address, length, callback) {}
 // TODO: What is the endianness of this???
 /**
  * Async function to read a single 4-byte word from memory.
+ * <br/>
+ *
+ * The read operation happens without verifying that the addresses are accessible or
+ * even exist. The address parameter needs to be 32-bit aligned (must be a multiple of 4).
+ * Note that if the target address is in unpowered RAM, the operation will fail.
  * <br/>
  *
  * Please note that the data is a number - it is NOT a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array|UInt32Array},
@@ -336,8 +345,12 @@ export function program(serialNumber, filename, options, progressCallback, callb
 
 
 /**
- * Async function to read a program from the device.
+ * Async function to read memory from the device and write the results into a file.
  * <br />
+ *
+ * The read operation happens without verifying that the addresses are accessible or
+ * even exist. Note that if the target address is in unpowered RAM, the operation will fail.
+ * <br/>
  *
  * This is the same functionality as running "<tt>nrfjprog --readcode</tt>" in the command-line tools.
  * @example
@@ -358,6 +371,8 @@ export function readToFile(serialNumber, filename, options, progressCallback, ca
 /**
  * Async function to verify the program in the device
  * <br/>
+ *
+ * Compares the contents of the provided .hex file against the contents of the memory of the device connected.<br/>
  *
  * This is the same functionality as running "<tt>nrfjprog --verify</tt>" in the command-line tools.
  *
@@ -398,8 +413,11 @@ export function erase(serialNumber, options, progressCallback, callback) {}
  * Async function to recover a device
  * <br/>
  *
- * Recover the whole chip by removing all user accessible content.
- * <br/>
+ * This operation attempts to recover the device and leave it as it was when it left Nordic factory. It will attempt to
+ * connect, erase all user available flash, halt and eliminate any protection. Note that this operation may take up to 30 s
+ * if the device was readback protected. Note as well that this function only affects internal flash and CPU, but does not
+ * erase, reset or stop any peripheral, oscillator source nor extarnally QSPI-connected flash. The operation will therefore
+ * leave the watchdog still operational if it was running.<br/>
  *
  * This is the same functionality as running "<tt>nrfjprog --recover</tt>" in the command-line tools.
  *

--- a/doc/api.js
+++ b/doc/api.js
@@ -1,0 +1,407 @@
+
+// This is a mock module, exporting the function fingerprints that are defined somewhere
+// else in the .h / .cpp files.
+//
+// The goal is to be able to run JSdoc against this file to generate fancy API docs.
+//
+// TODO: Move these docstrings to the corresponding .h/.cpp file
+// TODO: Become able to run JSdoc in .h/.cpp files, with a JSdoc plugin a la https://www.npmjs.com/package/jsdoc-jsx
+
+/**
+ *
+ * The <tt>nrfjprogjs</tt> module exposes the functionality to the
+ * nRF5x Command-line tools
+ * to your nodeJS programs.
+ *
+ * @example
+ * let nrfjprogjs = require('nrfjprogjs');
+ *
+ * nrfjprogjs.getConnectedDevices(function(err, devices) {
+ *     console.log('There are ' + devices.length + ' nRF devices connected.');
+ * })
+ *
+ * @module nrfjprogjs
+ */
+
+/**
+ * Possible error.<br/>
+ * If an operation completed sucessfully, the error passed to the callback
+ * function will be <tt>undefined</tt> (and thus, falsy).<br/>
+ * This will be an instance of the built-in {@link https://nodejs.org/dist/latest/docs/api/errors.html#errors_class_error|Error} class, with some extra properties:
+ * @typedef {Error} Error
+ * @property {integer} errno
+ *    The error number. Value will be one of the following predefined constants:<br/>
+ *    <tt>nrfjprogjs.CouldNotFindJlinkDLL</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotFindJProgDLL</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotOpenDevice</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotOpenDLL</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotConnectToDevice</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotCallFunction</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotErase</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotProgram</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotRead</tt><br/>
+ *    <tt>nrfjprogjs.CouldNotOpenHexFile</tt><br/>
+ *
+ * @property {String} errcode A human-readable version of the error code.
+ * @property {String} erroroperation The internal function that caused the error.
+ * @property {String} errmsg Error string. The value will be equal to that of the built-in <tt>message</tt> property.
+ * @property {integer} lowlevelErrorNo The low-level error code, if applicable.
+ * @property {String} lowlevelError A human-readable version of the low-level error code.
+ * @property {String} log The complete log from the internal functions.
+ *
+ * @example
+ * nrfprogjs.getDllVersion(function(err, version){
+ *     if (err) {
+ *         throw err;
+ *     } else {
+ *         // success
+ *     }
+ * });
+ *
+ * @example
+ * nrfprogjs.program(serialNumber, file, programmingOptions, function(err){
+ *     if (err && err.errno === nrfprogjs.CouldNotOpenHexFile) {
+ *          console.error('.hex file not found');
+ *     }
+ * });
+ */
+
+
+/**
+ * Represents a semver-like version number, e.g. 9.6.0 as an object of the form
+ *    <tt>{ major: 9, minor: 6, revision: 0 }</tt>
+ * @typedef Version
+ * @property {integer} major The major version number
+ * @property {integer} minor The minor version number
+ * @property {integer} revision The revision number
+ */
+
+/**
+ * Represents information of an individual device
+ * @typedef DeviceInformation
+ *
+ * @property {integer} family
+ *    Device family. Value will be equal to one of the following predefined constants:<br/>
+ *    <tt>nrfjprogjs.NRF51_FAMILY</tt><br/>
+ *    <tt>nrfjprogjs.NRF52_FAMILY</tt><br/>
+ *    <tt>nrfjprogjs.UNKNOWN_FAMILY</tt><br/>
+ *
+ * @property {integer} deviceType
+ *    Type of device. Value will be equal to one of the following predefined constants:<br/>
+ *    <tt>nrfjprogjs.NRF51xxx_xxAA_REV1</tt><br/>
+ *    <tt>nrfjprogjs.NRF51xxx_xxAA_REV2</tt><br/>
+ *    <tt>nrfjprogjs.NRF51xxx_xxAA_REV3</tt><br/>
+ *    <tt>nrfjprogjs.NRF51xxx_xxAB_REV3</tt><br/>
+ *    <tt>nrfjprogjs.NRF51xxx_xxAC_REV3</tt><br/>
+ *    <tt>nrfjprogjs.NRF51802_xxAA_REV3</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAA_ENGA</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAA_ENGB</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAA_REV1</tt><br/>
+ *    <tt>nrfjprogjs.NRF52840_xxAA_ENGA</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAA_FUTURE</tt><br/>
+ *    <tt>nrfjprogjs.NRF52840_xxAA_FUTURE</tt><br/>
+ *    <tt>nrfjprogjs.NRF52810_xxAA_REV1</tt><br/>
+ *    <tt>nrfjprogjs.NRF52810_xxAA_FUTURE</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAB_REV1</tt><br/>
+ *    <tt>nrfjprogjs.NRF52832_xxAB_FUTURE</tt><br/>
+ *    <tt>nrfjprogjs.NRF51801_xxAB_REV3</tt><br/>
+ *
+ * @property {integer} codeAddress
+ * @property {integer} codePageSize
+ * @property {integer} codeSize
+ *
+ * @property {integer} uicrAddress
+ * @property {integer} infoPageSize
+ *
+ * @property {boolean} codeRamPresent
+ * @property {integer} codeRamAddress
+ * @property {integer} dataRamAddress
+ * @property {integer} ramSize
+ *
+ * @property {boolean} qspiPresent
+ * @property {integer} xipAddress
+ * @property {integer} xipSize
+ *
+ * @property {integer} pinResetPin
+ */
+
+/**
+ * Represents the serial number and information of an individual device
+ * @typedef SerialNumberAndDeviceInformation
+ *
+ * @property {string} serialNumber
+ * @property {module:nrfjprogjs~DeviceInformation} deviceInfo
+ */
+
+/**
+ * Option flags to be used when sending a program to the device.
+ * @typedef ProgramOptions
+ * @property {integer} inputFormat=nrfjprogjs.INPUT_FORMAT_HEX_FILE
+ *    How the <tt>filename</tt> string passed to <tt>program()</tt> shall be interpreted.
+ *    Value must be one of:<br/>
+ *    <tt>nrfjprogjs.INPUT_FORMAT_HEX_FILE</tt>: The string represents a filename for a .hex file<br/>
+ *    <tt>nrfjprogjs.INPUT_FORMAT_HEX_STRING</tt>: The string represents the contents of a .hex file<br/>
+ * @property {boolean} verify=true
+ *    Whether verification should be performed as part of the programming.
+ *    Akin to <tt>nrfjprog --program --verify</tt> in the command-line tools
+ * @property {integer} chip_erase_mode=nrfjprogjs.ERASE_ALL
+ *    How much of the flash memory should be erased. Value must be one of:<br/>
+ *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
+ * @property {boolean} qspi_erase_mose=nrfjprogjs.ERASE_NONE
+ *    How much of the QSPI memory should be erased. Value must be one of:<br/>
+ *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
+ * @property {boolean} reset Whether the device should be reset after programming
+ */
+
+/**
+ * Erase flags to be used when sending a program to the device.
+ * @typedef EraseOptions
+ * @property {boolean} erase_mode
+ *    How much of the memory should be erased. Value must be one of:<br/>
+ *    <tt>nrfjprogjs.ERASE_NONE</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_ALL</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES</tt><br/>
+ *    <tt>nrfjprogjs.ERASE_PAGES_INCLUDING_UICR</tt><br/>
+ * @property {boolean} start_address
+ *    Start erasing from this address. Only relevant when using <tt>ERASE_PAGES</tt> or <tt>ERASE_PAGES_INCLUDING_UICR</tt> modes.
+ * @property {boolean} end_address
+ *    Erasing up to this address. Only relevant when using <tt>ERASE_PAGES</tt> or <tt>ERASE_PAGES_INCLUDING_UICR</tt> modes.
+ */
+
+/**
+ * Async function to get the version of the nrfjprog DLL in use.
+ *
+ * @example
+ * nrfjprogjs.getDllVersion( function(err, version) {
+ *      if (err) throw err;
+ *      console.log( version.major + '.' + version.minor + '.' + version.revision ) // e.g. 9.6.0
+ * } );
+ *
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, {@link module:nrfjprogjs~Version|Version}).
+ */
+export function getDllVersion() {}
+
+/**
+ * Async function to get a list of all connected devices.
+ *
+ * @example
+ * nrfjprogjs.getConnectedDevices( function(err, devices) {
+ *      if (err) throw err;
+ *      for (let i = 0; i < devices.length; i++) {
+ *          console.log(
+ *              devices[i].serialNumber +
+ *              ' has ' +
+ *              devices[i].deviceInfo.ramSize +
+ *              ' bytes of RAM'
+ *          );
+ *      }
+ * } );
+ *
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, Array of {@link module:nrfjprogjs~SerialNumberAndDeviceInformation|SerialNumberAndDeviceInformation}).
+ */
+export function getConnectedDevices(callback) {}
+
+
+
+/**
+ * Async function to get information of a single device, given its serial number.
+ *
+ * @example
+ * nrfjprogjs.getDeviceInfo(123456789, function(err, info) {
+ *      if (err) throw err;
+ *      console.log('Selected device has' + info.ramSize + ' bytes of RAM');
+ * } );
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, {@link module:nrfjprogjs~DeviceInformation|DeviceInformation}).
+ */
+export function getDeviceInfo(serialNumber, callback) {}
+
+
+
+/**
+ * Async function to read a chunk of memory. The data received by the callback
+ * is an array of integers, each of them representing a single byte (with values
+ * from 0 to 255).
+ * <br/>
+ *
+ * Please note that the data is an array of numbers - it is NOT a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array|UInt8Array},
+ * and it is NOT a {@link https://nodejs.org/api/buffer.html|Buffer}.
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --memrd</tt>" in the command-line tools.
+ *
+ * @example
+ * nrfjprogjs.read(123456789, 0, 16, function(err, data) {
+ *      if (err) throw err;
+ *      console.log('The first 16 bytes of memory look like: ' + data.join(','));
+ * } );
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} address The start address of the block of memory to be read
+ * @param {integer} length The amount of bytes to be read
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, Array of integers).
+ */
+export function read(serialNumber, address, length, callback) {}
+
+
+
+// TODO: What is the endianness of this???
+/**
+ * Async function to read a single 4-byte word from memory.
+ * <br/>
+ *
+ * Please note that the data is a number - it is NOT a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array|UInt32Array},
+ * and it is NOT a {@link https://nodejs.org/api/buffer.html|Buffer}.
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --memrd -w</tt>" in the command-line tools.
+ *
+ * @example
+ * nrfjprogjs.read(123456789, 0, function(err, data) {
+ *      if (err) throw err;
+ *      console.log('The first word of memory looks like: ' + data);
+ * } );
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} address The address of the word to be read
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect two parameters: ({@link module:nrfjprogjs~Error|Error}, integer).
+ */
+export function readU32(serialNumber, address, callback) {}
+
+
+
+/**
+ * Async function to push a program to the device.
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --program</tt>" in the command-line tools.
+ *
+ * @example
+ * nrfjprogjs.program(123456789, "/some/path/nrf52832_abcd.hex", {}, function(err) {
+ *      if (err) throw err;
+ * } );
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {string} filename Either the filename of the <tt>.hex</tt> file containing the program, or the contents of such a file.
+ * @param {module:nrfjprogjs~ProgramOptions} options A plain object containing options about how to push the program.
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function program(serialNumber, filename, options, callback) {}
+
+
+// TODO
+//     static NAN_METHOD(ReadToFile); // Params: serialNumber, filename, options {readram, readcode, readuicr, readqspi}, callback(error)
+export function readToFile(serialNumber, filename, options) {}
+
+
+/**
+ * Async function to verify the program in the device
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --verify</tt>" in the command-line tools.
+ *
+ * @example
+ * nrfjprogjs.verify(123456789, "/some/path/nrf52832_abcd.hex", function(err) {
+ *      if (err) throw err;
+ * } );
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {string} filename The filename of the <tt>.hex</tt> file containing the program.
+ * @param {Object} options={} Reserved for future use.
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function verify(serialNumber, filename, callback) {}
+
+
+
+/**
+ * Async function to erase a chunk of memory.
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --erasepage</tt>" in the command-line tools.<br/>
+ *
+ * Will not erase a locked device. To erase a locked device, use {@link module:nrfjprogjs~recover|recover}
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {module:nrfjprogjs~EraseOptions} options Options on how to erase the device memory
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function erase(serialNumber, options, callback) {}
+
+
+
+/**
+ * Async function to recover a device
+ * <br/>
+ *
+ * Recover the whole chip by removing all user accessible content.
+ * <br/>
+ *
+ * This is the same functionality as running "<tt>nrfjprog --recover</tt>" in the command-line tools.
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {module:nrfjprogjs~EraseOptions} filename The filename of the <tt>.hex</tt> file containing the program.
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function recover(serialNumber, filename, callback) {}
+
+
+// TODO: Check that this equates to "--memwr" and not to "--ramwr"
+/**
+ * Async function to write data to a device's memory, given an array of byte values.
+ * <br/>
+ *
+ * Please use an array of numbers -  a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array|UInt8Array}
+ * might work due to type casting, but a {@link https://nodejs.org/api/buffer.html|Buffer} will
+ * most likely fail.
+ * <br/>
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} address The filename of the <tt>.hex</tt> file containing the program.
+ * @param {Array.integer} data Array of byte values to be written
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function write(serialNumber, address, data, callback) {}
+
+
+// TODO: Check that this equates to "--memwr" and not to "--ramwr"
+/**
+ * Async function to write data to a device's memory, given the value for a single 4-byte word.
+ * <br/>
+ *
+ * Please use a single number as the parameter - do NOT use a
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array|UInt32Array}
+ * or a {@link https://nodejs.org/api/buffer.html|Buffer}.
+ * <br/>
+ *
+ * @param {integer} serialNumber The serial number of the device to query
+ * @param {integer} address The filename of the <tt>.hex</tt> file containing the program.
+ * @param {integer} data Array of byte values to be written
+ * @param {Function} callback A callback function to handle the async response.
+ *   It shall expect one parameter: ({@link module:nrfjprogjs~Error|Error}).
+ */
+export function writeU32(serialNumber, address, data, callback) {}
+
+
+
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "jshint api/ test/ && jscs api/ test/",
     "install": "node build.js",
-    "docs": "jsdoc doc/api.js -d doc/",
+    "docs": "jsdoc doc/api.js -t node_modules/minami/ -d doc/",
     "test": "jest --runInBand --verbose",
     "test-watch": "jest --watch --runInBand"
   },
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "jest": "^19.0.2",
-    "jsdoc": "^3.5.4"
+    "jsdoc": "^3.5.4",
+    "minami": "^1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "jshint api/ test/ && jscs api/ test/",
     "install": "node build.js",
+    "docs": "jsdoc doc/api.js -d doc/",
     "test": "jest --runInBand --verbose",
     "test-watch": "jest --watch --runInBand"
   },
@@ -25,6 +26,7 @@
     "nan": "2.3.3"
   },
   "devDependencies": {
-    "jest": "^19.0.2"
+    "jest": "^19.0.2",
+    "jsdoc": "^3.5.4"
   }
 }

--- a/src/nrfjprog_helpers.cpp
+++ b/src/nrfjprog_helpers.cpp
@@ -108,7 +108,7 @@ EraseOptions::EraseOptions(v8::Local<v8::Object> obj) :
 ReadToFileOptions::ReadToFileOptions(v8::Local<v8::Object> obj)
 {
     options.readram = false;
-    options.readcode = false;
+    options.readcode = true;
     options.readuicr = false;
     options.readqspi = false;
 

--- a/src/nrfjprogjs.cpp
+++ b/src/nrfjprogjs.cpp
@@ -610,7 +610,8 @@ NAN_METHOD(nRFjprog::Program)
 
         programResult = dll_function.program(probe, baton->filename.c_str(), baton->options);
 
-        if (programResult == NOT_AVAILABLE_BECAUSE_PROTECTION)
+        if (programResult == NOT_AVAILABLE_BECAUSE_PROTECTION &&
+            baton->options.chip_erase_mode == ERASE_ALL)
         {
             const nrfjprogdll_err_t recoverResult = dll_function.recover(probe);
 

--- a/src/nrfjprogjs.h
+++ b/src/nrfjprogjs.h
@@ -77,7 +77,7 @@ private:
     static NAN_METHOD(Program); // Params: serialnumber, filename, options {verify, chip_erase_mode, qspi_erase_mode, reset}, callback(error)
     static NAN_METHOD(ReadToFile); // Params: serialnumber, filename, options {readram, readcode, readuicr, readqspi}, callback(error)
     static NAN_METHOD(Verify); // Params: serialnumber, filename, callback(error)
-    static NAN_METHOD(Erase); // Params: serialnumber, options {erasse_mode, start_address, end_address}, callback(error)
+    static NAN_METHOD(Erase); // Params: serialnumber, options {erase_mode, start_address, end_address}, callback(error)
 
     static NAN_METHOD(Recover); // Params: serialnumber, callback(error)
 


### PR DESCRIPTION
I started experimenting with `pc-nrfprog-js`, got annoyed at the lack of documentation, and started writing some jsdoc docstrings.

*Then* I noticed there was a `doc` branch.

This PR uses most of the docstrings from https://github.com/NordicSemiconductor/pc-nrfjprog-js/commit/26620fb81233f6c7e05f094dc7191449ff1c90c2 and https://github.com/NordicSemiconductor/pc-nrfjprog-js/commit/955f08ff6a8360737bac437aaf34d46284c378f5 , plus my best guesses at some stuff and some tiny code examples and formatting.