### PR TITLE
Add configuration for publishing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/*
 /node_modules
 /CMakeFiles
+/docs

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # pc-nrfjprog-js
-This project provides programming of Nordic Semiconductor nRF51 and nRF52 devices using nrfjprog.
+
+Node.js library that exposes the functionality of the [nRF5x Command-Line-Tools](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html?cp=5_1), used for development, programming, and debugging of Nordic Semiconductor's nRF5x SoCs (System on Chip).
+
+## Installing
+
+The following tools required for building the project:
+
+* Node.js (>=4)
+* npm (>=3.7.0)
+* CMake (>=2.8.12)
+* A C/C++ toolchain
+
+To install dependencies and build the project:
+
+    npm install
+
+### nRF5x-Command-Line-Tools
+
+Before using the library, nRF5x-Command-Line-Tools must to be installed. The project includes nRF5x-Command-Line-Tools installers/archives for all supported platforms in the `nrfjprog` directory.
+
+#### Windows
+
+Run the nRF-Command-Line-Tools installer (exe) from the `nrfjprog` directory. This will install the required nrfjprog libraries and SEGGER J-Link.
+
+#### Linux/macOS
+
+Download and install [SEGGER J-Link](https://www.segger.com/downloads/jlink/).
+
+Extract the nRF-Command-Line-Tools tar file from the `nrfjprog` directory, f.ex.:
+
+    sudo tar -xf nRF5x-Command-Line-Tools_<version>_<platform>.tar -C /opt
+
+This will create a directory `/opt/nrfjprog` containing the nrfjprog libraries. These libraries must be available for the process that uses pc-nrfjprog-js, f.ex. by adding the nrfjprog directory to `LD_LIBRARY_PATH`:
+
+    export LD_LIBRARY_PATH=/opt/nrfjprog
+
+## API documentation
+
+http://nordicsemiconductor.github.io/pc-nrfjprog-js/
+
+## Example
+
+```
+let nrfjprogjs = require('pc-nrfjprog-js');
+
+nrfjprogjs.getConnectedDevices(function(err, devices) {
+    console.log('There are ' + devices.length + ' nRF devices connected.');
+});
+```
+
+## Tests
+
+The project has integration tests that runs against a devkit/dongle. Note that these tests will erase the contents on the connected devkit/dongle. To run the tests:
+
+    npm test

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ nrfjprogjs.getConnectedDevices(function(err, devices) {
 
 ## Tests
 
-The project has integration tests that runs against a devkit/dongle. Note that these tests will erase the contents on the connected devkit/dongle. To run the tests:
+The project has integration tests that run against a devkit/dongle. Note that these tests will erase the contents on the connected devkit/dongle. To run the tests:
 
     npm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "jshint api/ test/ && jscs api/ test/",
     "install": "node build.js",
     "docs": "jsdoc doc/api.js -t node_modules/minami -R README.md -d docs",
+    "deploy-docs": "gh-pages -d docs",
     "test": "jest --runInBand --verbose",
     "test-watch": "jest --watch --runInBand"
   },
@@ -26,6 +27,7 @@
     "nan": "2.3.3"
   },
   "devDependencies": {
+    "gh-pages": "^1.0.0",
     "jest": "^19.0.2",
     "jsdoc": "^3.5.4",
     "minami": "^1.2.3"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "jshint api/ test/ && jscs api/ test/",
     "install": "node build.js",
-    "docs": "jsdoc doc/api.js -t node_modules/minami -d docs",
+    "docs": "jsdoc doc/api.js -t node_modules/minami -R README.md -d docs",
     "test": "jest --runInBand --verbose",
     "test-watch": "jest --watch --runInBand"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "jshint api/ test/ && jscs api/ test/",
     "install": "node build.js",
-    "docs": "jsdoc doc/api.js -t node_modules/minami/ -d doc/",
+    "docs": "jsdoc doc/api.js -t node_modules/minami -d docs",
     "test": "jest --runInBand --verbose",
     "test-watch": "jest --watch --runInBand"
   },


### PR DESCRIPTION
Adding config for publishing docs, plus some more information in README.md. The documentation is available on http://nordicsemiconductor.github.io/pc-nrfjprog-js/.