### PR TITLE
Fix issue where the application would not terminate correctly when done.

### DIFF
--- a/src/nrfjprogjs_batons.h
+++ b/src/nrfjprogjs_batons.h
@@ -63,6 +63,8 @@ public:
 
     virtual ~Baton()
     {
+        delete req;
+
         if (callback != nullptr)
         {
             delete callback;


### PR DESCRIPTION
Move creation and destruction of progress events to the execute function so that the progress event is not holding up the execution after application is done.