### PR TITLE
Add test results that can be parsed by Bamboo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /CMakeFiles
 /docs
 /nrfjprog/unpacked
+/jest.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "install": "node build.js",
     "docs": "jsdoc doc/api.js -t node_modules/minami -R README.md -d docs",
     "deploy-docs": "gh-pages -d docs",
-    "test": "node run-tests.js --runInBand --verbose"
+    "test": "node run-tests.js --runInBand --verbose --testResultsProcessor jest-bamboo-formatter",
+    "test-watch": "jest --watch --runInBand"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "gh-pages": "^1.0.0",
     "jest": "^19.0.2",
+    "jest-bamboo-formatter": "1.0.1",
     "jsdoc": "^3.5.4",
     "minami": "^1.2.3",
     "tar": "2.2.1"


### PR DESCRIPTION
Jest will now output test results to jest.json, which can be parsed and displayed by Bamboo.