### PR TITLE
Check for Node.js 32-bit when installing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If you are encountering errors like `Errorcode: CouldNotFindJprogDLL (0x2)` or `
 
 Run the nRF-Command-Line-Tools installer (exe). This will install the required nrfjprog libraries and SEGGER J-Link.
 
+Note that the nRF-Command-Line-Tools for Windows is only available in 32-bit at the moment. This means that 32-bit Node.js is required in order to use pc-nrfjprog-js on Windows.
+
 ### Linux/macOS
 
 Download and install [SEGGER J-Link](https://www.segger.com/downloads/jlink/).

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -70,27 +70,27 @@ getLibraryVersion()
         console.log('J-Link libraries seem to be working as expected.');
     })
     .catch(err => {
-        console.log();
-        console.log(chalk.red.bold(`Found error: ${err.errcode}`));
+        console.error();
+        console.error(chalk.red.bold(`Found error: ${err.errcode}`));
 
         const isNrfjprogError = err.errno === 2 && err.errcode === 'CouldNotFindJprogDLL';
         const isJlinkError = err.errno === 7 && err.errcode === 'CouldNotOpenDLL'
             && err.lowlevelError === 'JLINKARM_DLL_NOT_FOUND';
 
         if (isNrfjprogError) {
-            console.log('WARNING: The automated setup of nrfjprog libraries failed. The ' +
+            console.error('WARNING: The automated setup of nrfjprog libraries failed. The ' +
                 'pc-nrfjprog-js library cannot function without them.');
-            console.log(chalk.bold('Please install nRF5x Command Line Tools manually from ' +
+            console.error(chalk.bold('Please install nRF5x Command Line Tools manually from ' +
                 'the Nordic Semiconductor website.'));
         } else if (isJlinkError) {
-            console.log('WARNING: The J-Link libraries were not found on your system. The ' +
+            console.error('WARNING: The J-Link libraries were not found on your system. The ' +
                 'pc-nrfjprog-js library cannot function without them.');
-            console.log(chalk.bold('Please visit https://www.segger.com/downloads/jlink/ and ' +
+            console.error(chalk.bold('Please visit https://www.segger.com/downloads/jlink/ and ' +
                 'install the "J-Link Software and Documentation Pack".'));
         } else {
-            console.log('The pc-nrfjprog-js post-install check failed unexpectedly:', err.message);
+            console.error('The pc-nrfjprog-js post-install check failed unexpectedly:', err.message);
         }
 
-        console.log();
+        console.error();
         process.exit(1);
     });

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -160,7 +160,10 @@ function removeFileIfExists(filePath) {
 const platform = os.platform();
 const platformConfig = PLATFORM_CONFIG[platform];
 
-if (!platformConfig) {
+if (platform === 'win32' && os.arch() !== 'ia32') {
+    throw new Error(`Unsupported architecture: ${os.arch()}. On Windows, the nrfjprog libraries ` +
+        'currently require 32-bit Node.js.');
+} else if (!platformConfig) {
     throw new Error(`Unsupported platform: '${platform}'. Cannot install nrfjprog libraries.`);
 }
 

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -161,10 +161,12 @@ const platform = os.platform();
 const platformConfig = PLATFORM_CONFIG[platform];
 
 if (platform === 'win32' && os.arch() !== 'ia32') {
-    throw new Error(`Unsupported architecture: ${os.arch()}. On Windows, the nrfjprog libraries ` +
+    console.log(`Unsupported architecture: ${os.arch()}. On Windows, the nrfjprog libraries ` +
         'currently require 32-bit Node.js.');
+    process.exit(1);
 } else if (!platformConfig) {
-    throw new Error(`Unsupported platform: '${platform}'. Cannot install nrfjprog libraries.`);
+    console.log(`Unsupported platform: '${platform}'. Cannot install nrfjprog libraries.`);
+    process.exit(1);
 }
 
 // Check if nrfjprog libraries are working or not

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -161,11 +161,11 @@ const platform = os.platform();
 const platformConfig = PLATFORM_CONFIG[platform];
 
 if (platform === 'win32' && os.arch() !== 'ia32') {
-    console.log(`Unsupported architecture: ${os.arch()}. On Windows, the nrfjprog libraries ` +
+    console.error(`Unsupported architecture: ${os.arch()}. On Windows, the nrfjprog libraries ` +
         'currently require 32-bit Node.js.');
     process.exit(1);
 } else if (!platformConfig) {
-    console.log(`Unsupported platform: '${platform}'. Cannot install nrfjprog libraries.`);
+    console.error(`Unsupported platform: '${platform}'. Cannot install nrfjprog libraries.`);
     process.exit(1);
 }
 
@@ -187,12 +187,12 @@ getLibraryVersion()
             .then(() => installNrfjprog(platformConfig.destinationFile))
             .catch(error => {
                 exitCode = 1;
-                console.log(`Error when installing nrfjprog libraries: ${error.message}`);
+                console.error(`Error when installing nrfjprog libraries: ${error.message}`);
             })
             .then(() => removeFileIfExists(platformConfig.destinationFile))
             .catch(error => {
                 exitCode = 1;
-                console.log(`Unable to remove downloaded nrfjprog artifact: ${error.message}`);
+                console.error(`Unable to remove downloaded nrfjprog artifact: ${error.message}`);
             })
             .then(() => process.exit(exitCode));
     });


### PR DESCRIPTION
The library currently only supports 32-bit Node.js when running on Windows. Now checking this and printing an error during installation.