### PR TITLE
Use nrfjprog v9.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node-pre-gyp": "^0.6.39",
     "opn": "^5.2.0",
     "sander": "^0.6.0",
+    "semver": "^5.5.0",
     "tar": "^4.3.3"
   },
   "devDependencies": {

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -145,22 +145,30 @@ function isHeaderFileInstalledWin32() {
     }
 }
 
-function installNrfjprog(pathToArtifact) {
-    if (pathToArtifact.endsWith('.tar')) {
-        console.log(`Extracting ${pathToArtifact} to ${LIB_DIR}...`);
-        return extractTarFile(pathToArtifact, LIB_DIR);
-    } else if (pathToArtifact.endsWith('.exe')) {
-        console.log(`Running nrfjprog installer at ${pathToArtifact}...`);
-        return opn(pathToArtifact);
-    }
-    return Promise.reject(new Error(`Unsupported nrfjprog artifact: ${pathToArtifact}`));
-}
-
 function removeFileIfExists(filePath) {
     if (sander.existsSync(filePath)) {
         return sander.unlink(filePath);
     }
     return Promise.resolve();
+}
+
+function removeDirIfExists(dirPath) {
+    if (sander.existsSync(dirPath)) {
+        return sander.rimraf(dirPath);
+    }
+    return Promise.resolve();
+}
+
+function installNrfjprog(pathToArtifact) {
+    if (pathToArtifact.endsWith('.tar')) {
+        console.log(`Extracting ${pathToArtifact} to ${LIB_DIR}...`);
+        return removeDirIfExists(LIB_DIR)
+            .then(() => extractTarFile(pathToArtifact, LIB_DIR));
+    } else if (pathToArtifact.endsWith('.exe')) {
+        console.log(`Running nrfjprog installer at ${pathToArtifact}...`);
+        return opn(pathToArtifact);
+    }
+    return Promise.reject(new Error(`Unsupported nrfjprog artifact: ${pathToArtifact}`));
 }
 
 const platform = os.platform();

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -181,7 +181,8 @@ getLibraryVersion()
         if (version.major < REQUIRED_VERSION.major ||
             version.minor < REQUIRED_VERSION.minor ||
             version.revision < REQUIRED_VERSION.revision) {
-            console.log(`Found nrfjprog version ${version}, but ${REQUIRED_VERSION} is required`);
+            console.log(`Found nrfjprog version ${JSON.stringify(version)}, ` +
+                `but ${JSON.stringify(REQUIRED_VERSION)} is required`);
             isInstallationRequired = true;
         } else {
             console.log('Found nrfjprog libraries at required version', version);

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -56,6 +56,7 @@ const sander = require('sander');
 const os = require('os');
 const path = require('path');
 const opn = require('opn');
+const semver = require('semver');
 
 const DOWNLOAD_DIR = path.join(__dirname, '..', 'nrfjprog');
 const LIB_DIR = path.join(DOWNLOAD_DIR, 'lib');
@@ -186,11 +187,12 @@ if (platform === 'win32' && os.arch() !== 'ia32') {
 let isInstallationRequired = false;
 getLibraryVersion()
     .then(version => {
-        if (version.major < REQUIRED_VERSION.major ||
-            version.minor < REQUIRED_VERSION.minor ||
-            version.revision < REQUIRED_VERSION.revision) {
-            console.log(`Found nrfjprog version ${JSON.stringify(version)}, ` +
-                `but ${JSON.stringify(REQUIRED_VERSION)} is required`);
+        const currentVersion = `${version.major}.${version.minor}.${version.revision}`;
+        const requiredVersion = `${REQUIRED_VERSION.major}.${REQUIRED_VERSION.minor}` +
+            `.${REQUIRED_VERSION.revision}`;
+        if (semver.lt(currentVersion, requiredVersion)) {
+            console.log(`Found nrfjprog version ${currentVersion}, but ` +
+                `${requiredVersion} is required`);
             isInstallationRequired = true;
         } else {
             console.log('Found nrfjprog libraries at required version', version);

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -62,17 +62,17 @@ const LIB_DIR = path.join(DOWNLOAD_DIR, 'lib');
 const PLATFORM_CONFIG = {
     linux: {
         // See https://www.nordicsemi.com/eng/nordic/Products/nRF51822/nRF5x-Command-Line-Tools-Linux64/51386
-        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/51386/27/17243451/94917',
+        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/51386/28/82499208/94917',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-linux64.tar'),
     },
     darwin: {
         // See https://www.nordicsemi.com/eng/nordic/Products/nRF51822/nRF5x-Command-Line-Tools-OSX/53402
-        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/53402/19/93375824/99977',
+        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/53402/20/87602525/99977',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-darwin.tar'),
     },
     win32: {
         // See https://www.nordicsemi.com/eng/nordic/Products/nRF51822/nRF5x-Command-Line-Tools-Win32/33444
-        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/33444/47/97153666/53210',
+        url: 'https://www.nordicsemi.com/eng/nordic/download_resource/33444/48/95932377/53210',
         destinationFile: path.join(DOWNLOAD_DIR, 'nrfjprog-win32.exe'),
     },
 };


### PR DESCRIPTION
Now using nrfjprog v9.7.3 with this library. When running `npm install`, we verify that pc-nrfjprog-js can access the nrfjprog libraries, and that the current version is v9.7.3 or above. If not, we download and install it.