### PR TITLE
Added possibility of skipping nrfjprog library version at pre and post install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This will pull down precompiled binaries for your platform/runtime environment. 
 * CMake (>=2.8.12)
 * A C/C++ toolchain
 
+As part of the installation procedure, pc-nrfjprog-js will check if it can access the nrfjprog libraries, and verify that they are up to date. If not, it will try to install/upgrade these libraries. This check can be skipped by setting environment variable `SKIP_NRFJPROG_CHECK=true` before installing pc-nrfjprog-js.
+
 ## Required setup
 
 Before using the library, some platform specific setup is required. If you are seeing errors like `Errorcode: CouldNotFindJprogDLL (0x2)` or `Errorcode: CouldNotLoadDLL (0x3)` then please check that the tools described below are properly installed.

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -48,7 +48,8 @@ const chalk = require('chalk');
 
 // SKIP_NRFJPROG_CHECK environment variable allows to skip checking
 // for the purpose of publishing job on build server
-if (process.env.SKIP_NRFJPROG_CHECK) {
+const skipNrfjprogCheck = (process.env.SKIP_NRFJPROG_CHECK || false).toString().toUpperCase();
+if (['1', 'ON', 'TRUE', 'Y', 'YES'].includes(skipNrfjprogCheck)) {
     console.log('Skipping nrfjprog library version check.');
     process.exit(0);
 }

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -46,6 +46,13 @@
 
 const chalk = require('chalk');
 
+// SKIP_NRFJPROG_CHECK environment variable allows to skip checking
+// for the purpose of publishing job on build server
+if (process.env.SKIP_NRFJPROG_CHECK) {
+    console.log('Skipping nrfjprog library version check.');
+    process.exit(0);
+}
+
 function getLibraryVersion() {
     return new Promise((resolve, reject) => {
         try {

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -60,7 +60,8 @@ const semver = require('semver');
 
 // SKIP_NRFJPROG_CHECK environment variable allows to skip checking
 // for the purpose of publishing job on build server
-if (process.env.SKIP_NRFJPROG_CHECK) {
+const skipNrfjprogCheck = (process.env.SKIP_NRFJPROG_CHECK || false).toString().toUpperCase();
+if (['1', 'ON', 'TRUE', 'Y', 'YES'].includes(skipNrfjprogCheck)) {
     console.log('Skipping nrfjprog library version check.');
     process.exit(0);
 }

--- a/scripts/pre-install.js
+++ b/scripts/pre-install.js
@@ -58,6 +58,13 @@ const path = require('path');
 const opn = require('opn');
 const semver = require('semver');
 
+// SKIP_NRFJPROG_CHECK environment variable allows to skip checking
+// for the purpose of publishing job on build server
+if (process.env.SKIP_NRFJPROG_CHECK) {
+    console.log('Skipping nrfjprog library version check.');
+    process.exit(0);
+}
+
 const DOWNLOAD_DIR = path.join(__dirname, '..', 'nrfjprog');
 const LIB_DIR = path.join(DOWNLOAD_DIR, 'lib');
 const PLATFORM_CONFIG = {


### PR DESCRIPTION
In build server environment when publishing job is executed we need a way to skip the library version check at pre and post install stages.