### PR TITLE
Fix/logging

### DIFF
--- a/__tests__/rtt.test.js
+++ b/__tests__/rtt.test.js
@@ -114,7 +114,7 @@ describe('RTT', () => {
             RTT.start(0, {}, startCallback);
         });
 
-        it.only('returns an error when using wrong control block location', done => {
+        it('returns an error when using wrong control block location', done => {
             const startCallback = (err, down, up) => {
                 expect(err).toBeDefined();
                 expect(err).toMatchSnapshot();

--- a/__tests__/rtt.test.js
+++ b/__tests__/rtt.test.js
@@ -114,7 +114,7 @@ describe('RTT', () => {
             RTT.start(0, {}, startCallback);
         });
 
-        it('returns an error when using wrong control block location', done => {
+        it.only('returns an error when using wrong control block location', done => {
             const startCallback = (err, down, up) => {
                 expect(err).toBeDefined();
                 expect(err).toMatchSnapshot();

--- a/src/highlevel.h
+++ b/src/highlevel.h
@@ -44,6 +44,7 @@
 #include "utility/errormessage.h"
 
 #include <functional>
+#include <memory>
 
 class Baton;
 
@@ -120,6 +121,7 @@ private:
     static Probe_handle_t probe;
 
     static std::string logMessage;
+    static std::timed_mutex logMutex;
 };
 
 #endif // __NRFJPROG_H__

--- a/src/rtt.cpp
+++ b/src/rtt.cpp
@@ -260,20 +260,29 @@ void RTT::resetLog()
     logItemCount = 0;
 }
 
+#include <iostream>
+#include <fstream>
+
 void RTT::log(const char *msg)
 {
+    std::ofstream myfile;
+    myfile.open ("logger.log", std::ios::out | std::ios::app);
+    myfile << "logItemCount #" << logItemCount << " LogLength: " << logMessage.length() << std::endl;
+    myfile << "Message: " << msg << std::endl;
+    myfile.close();
+
     if (logItemCount > 10000)
     {
         if (appendToLog)
         {
-            logMessage = logMessage.append("The log has more than 10000 items. No more items will be logged.");
+            logMessage.append("The log has more than 10000 items. No more items will be logged.");
             appendToLog = false;
         }
 
         return;
     }
 
-    logMessage = logMessage.append(msg);
+    logMessage.append(msg);
     logItemCount++;
 }
 

--- a/src/rtt.cpp
+++ b/src/rtt.cpp
@@ -197,8 +197,9 @@ void RTT::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info, rtt_parse_parameters_func
     log("Start of ");
     log(baton->name.c_str());
     log("\n");
+    log(baton->toString().c_str());
+    log("\n");
     log("===============================================\n");
-
 
     baton->executeFunction = execute;
     baton->returnFunction = ret;

--- a/src/rtt.cpp
+++ b/src/rtt.cpp
@@ -201,6 +201,10 @@ void RTT::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info, rtt_parse_parameters_func
     log("\n");
     log("===============================================\n");
 
+    for (int i = 0; i < 100000; i++) {
+        log("This is a long log message that I want to log to figure out how long I can actually get the log");
+    }
+
     baton->executeFunction = execute;
     baton->returnFunction = ret;
 
@@ -268,10 +272,10 @@ void RTT::log(const char *msg)
 {
     std::ofstream myfile;
     myfile.open ("logger.log", std::ios::out | std::ios::app);
-    myfile << "logItemCount #" << logItemCount << " LogLength: " << logMessage.length() << std::endl;
+    myfile << "logItemCount #" << logItemCount << " LogLength: " << logMessage.length() << " Max Length: " << logMessage.max_size() << std::endl;
     myfile << "Message: " << msg << std::endl;
     myfile.close();
-
+/*
     if (logItemCount > 10000)
     {
         if (appendToLog)
@@ -282,7 +286,7 @@ void RTT::log(const char *msg)
 
         return;
     }
-
+*/
     logMessage.append(msg);
     logItemCount++;
 }
@@ -355,6 +359,7 @@ RTTErrorcodes_t RTT::getDeviceInformation(RTTStartBaton *baton)
 RTTErrorcodes_t RTT::waitForControlBlock(RTTStartBaton *baton)
 {
     while (true) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         bool controlBlockFound = false;
         RETURN_ERROR_ON_FAIL(libraryFunctions.rtt_is_control_block_found(&controlBlockFound), RTTCouldNotCallFunction);
 
@@ -364,12 +369,11 @@ RTTErrorcodes_t RTT::waitForControlBlock(RTTStartBaton *baton)
 
         auto attemptedStartupTime = std::chrono::high_resolution_clock::now();
 
-        if (std::chrono::duration_cast<std::chrono::seconds>(attemptedStartupTime - rttStartTime).count() > 10) {
+        if (std::chrono::duration_cast<std::chrono::seconds>(attemptedStartupTime - rttStartTime).count() > 5) {
             cleanup();
             return RTTCouldNotFindControlBlock;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     return RTTSuccess;

--- a/src/rtt.h
+++ b/src/rtt.h
@@ -45,6 +45,7 @@
 
 #include <functional>
 #include <chrono>
+#include <memory>
 
 class RTTBaton;
 class RTTStartBaton;
@@ -95,8 +96,7 @@ private:
     static void resetLog();
 
     static std::string logMessage;
-    static bool appendToLog;
-    static int logItemCount;
+    static std::timed_mutex logMutex;
     static bool libraryLoaded;
     static std::chrono::high_resolution_clock::time_point rttStartTime;
 

--- a/src/rtt_batons.h
+++ b/src/rtt_batons.h
@@ -64,6 +64,11 @@ public:
         return returnParameterCount + 1;
     }
 
+    virtual std::string toString()
+    {
+        return std::string();
+    }
+
     const uint32_t returnParameterCount;
     const std::string name;
 
@@ -83,10 +88,25 @@ public:
 
 std::timed_mutex RTTBaton::executionMutex;
 
+#include <sstream>
+#include <string>
+
 class RTTStartBaton : public RTTBaton
 {
 public:
     RTTStartBaton() : RTTBaton("start rtt", 2) {}
+    std::string toString()
+    {
+        std::stringstream stream;
+
+        stream << "Parameters:" << std::endl;
+        stream << "Serialnumber: " << serialNumber << std::endl;
+        stream << "Has Controlblock: " << (hasControlBlockLocation ? "true" : "false") << std::endl;
+        stream << "Controlblock location: " << controlBlockLocation << std::endl;
+
+        return stream.str();
+    }
+
     uint32_t serialNumber;
     bool hasControlBlockLocation;
     uint32_t controlBlockLocation;
@@ -103,12 +123,30 @@ class RTTStopBaton : public RTTBaton
 {
 public:
     RTTStopBaton() : RTTBaton("stop rtt", 0) {}
+    std::string toString()
+    {
+        std::stringstream stream;
+
+        stream << "No parameters";
+
+        return stream.str();
+    }
 };
 
 class RTTReadBaton : public RTTBaton
 {
 public:
     RTTReadBaton() : RTTBaton("rtt read", 3) {}
+    std::string toString()
+    {
+        std::stringstream stream;
+
+        stream << "Parameters:" << std::endl;
+        stream << "ChanneldIndex: " << channelIndex << std::endl;
+        stream << "Length wanted: " << length << std::endl;
+
+        return stream.str();
+    }
 
     uint32_t channelIndex;
     uint32_t length;
@@ -119,6 +157,17 @@ class RTTWriteBaton : public RTTBaton
 {
 public:
     RTTWriteBaton() : RTTBaton("rtt write", 2) {}
+    std::string toString()
+    {
+        std::stringstream stream;
+
+        stream << "Parameters:" << std::endl;
+        stream << "ChanneldIndex: " << channelIndex << std::endl;
+        stream << "Length wanted: " << length << std::endl;
+        stream << "Data" << data.data() << std::endl;
+
+        return stream.str();
+    }
 
     uint32_t channelIndex;
     uint32_t length;

--- a/src/rtt_batons.h
+++ b/src/rtt_batons.h
@@ -38,6 +38,8 @@
 #define RTT_BATONS_H
 
 #include <memory>
+#include <sstream>
+#include <string>
 #include "rtt.h"
 #include "rtt_helpers.h"
 
@@ -87,9 +89,6 @@ public:
 };
 
 std::timed_mutex RTTBaton::executionMutex;
-
-#include <sstream>
-#include <string>
 
 class RTTStartBaton : public RTTBaton
 {


### PR DESCRIPTION
This fix is due to a segmentation fault found on Mac (and occasionally on Linux). The bug is related to the logMessage in the RTT, and was triggered by the RTT test `returns an error when using wrong control block location`. The reason for this triggering is that `nrfjprog` has increased the number of log messages they send, so due to the increased number of messages, a flaw in the log function crashed everything.
- [x] Improve the logging in RTT and Highlevel by adding a lock making the log function thread safe.
- [x] Removed redundant assignment risking triggering copy constructor of std::string
- [x] Changed how often waitForControlBlock checks for the control block, and how long it is checked.