### PR TITLE
A call to open when a device is already open should return in an error.

### DIFF
--- a/__tests__/single-device-non-destructive.test.js
+++ b/__tests__/single-device-non-destructive.test.js
@@ -179,6 +179,19 @@ describe('Single device - non-destructive', () => {
         });
     });
 
+    it('calling close twice has no effect', done => {
+        nRFjprog.open(device.serialNumber, (err) => {
+            expect(err).toBeUndefined();
+            nRFjprog.close(device.serialNumber, (err) => {
+                expect(err).toBeUndefined();
+                nRFjprog.close(device.serialNumber, (err) => {
+                    expect(err).toBeUndefined();
+                    done();
+                });
+            });
+        });
+    });
+
     it('reads more than 0x10000 bytes', done => {
         const readLength = 0x10004;
 

--- a/__tests__/single-device-non-destructive.test.js
+++ b/__tests__/single-device-non-destructive.test.js
@@ -153,6 +153,32 @@ describe('Single device - non-destructive', () => {
         });
     });
 
+    it('calling open twice returns an error', done => {
+        nRFjprog.open(device.serialNumber, (err) => {
+            expect(err).toBeUndefined();
+            nRFjprog.open(device.serialNumber, (err) => {
+                expect(err).toBeDefined();
+                done();
+            });
+        });
+    });
+
+    it('should be able to reopen after close', done => {
+        nRFjprog.open(device.serialNumber, (err) => {
+            expect(err).toBeUndefined();
+            nRFjprog.close(device.serialNumber, (err) => {
+                expect(err).toBeUndefined();
+                nRFjprog.open(device.serialNumber, (err) => {
+                    expect(err).toBeUndefined();
+                    nRFjprog.close(device.serialNumber, (err) => {
+                        expect(err).toBeUndefined();
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
     it('reads more than 0x10000 bytes', done => {
         const readLength = 0x10004;
 

--- a/doc/api.js
+++ b/doc/api.js
@@ -594,7 +594,7 @@ export function writeU32(serialNumber, address, data, callback) {}
  * If a connection to a device is opened, then all subsequent calls will use the
  * already-opened connection. Opening a connection twice will close the first
  * connection and return an error. Closing a connection twice will close it on
- * the first `close()` call: the second one will return an error.<br />
+ * the first `close()` call: the second one will have no effect.<br />
  *
  * @example
  * nrfjprogjs.read(123456789, 0, function(err, data) {

--- a/doc/api.js
+++ b/doc/api.js
@@ -592,9 +592,9 @@ export function writeU32(serialNumber, address, data, callback) {}
  * Open connections shall be closed by calling {@link module:pc-nrfjprog-js~close|close}
  *
  * If a connection to a device is opened, then all subsequent calls will use the
- * already-opened connection. Opening a connection twice has no effect. Closing
- * a connection twice will close it on the first `close()` call: the second
- * one will have no effect.<br />
+ * already-opened connection. Opening a connection twice will close the first
+ * connection and return an error. Closing a connection twice will close it on
+ * the first `close()` call: the second one will return an error.<br />
  *
  * @example
  * nrfjprogjs.read(123456789, 0, function(err, data) {

--- a/src/highlevel.cpp
+++ b/src/highlevel.cpp
@@ -944,6 +944,7 @@ NAN_METHOD(HighLevel::OpenDevice)
     execute_function_t e = [&] (Baton *b, Probe_handle_t probe) -> nrfjprogdll_err_t {
         if (keepDeviceOpen)
         {
+            keepDeviceOpen = false;
             return INVALID_OPERATION; // Already opened
         }
         keepDeviceOpen = true;

--- a/src/highlevel.cpp
+++ b/src/highlevel.cpp
@@ -942,6 +942,10 @@ NAN_METHOD(HighLevel::OpenDevice)
     };
 
     execute_function_t e = [&] (Baton *b, Probe_handle_t probe) -> nrfjprogdll_err_t {
+        if (keepDeviceOpen)
+        {
+            return INVALID_OPERATION; // Already opened
+        }
         keepDeviceOpen = true;
         return SUCCESS;
     };
@@ -956,6 +960,10 @@ NAN_METHOD(HighLevel::CloseDevice)
     };
 
     execute_function_t e = [&] (Baton *b, Probe_handle_t probe) -> nrfjprogdll_err_t {
+        if (!keepDeviceOpen)
+        {
+            return INVALID_OPERATION; // Already closed
+        }
         keepDeviceOpen = false;
         return SUCCESS;
     };

--- a/src/highlevel.cpp
+++ b/src/highlevel.cpp
@@ -961,10 +961,6 @@ NAN_METHOD(HighLevel::CloseDevice)
     };
 
     execute_function_t e = [&] (Baton *b, Probe_handle_t probe) -> nrfjprogdll_err_t {
-        if (!keepDeviceOpen)
-        {
-            return INVALID_OPERATION; // Already closed
-        }
         keepDeviceOpen = false;
         return SUCCESS;
     };


### PR DESCRIPTION
OpenDevice will now return an error if a device is already open, and close device will return an error if no device is open.