### PR TITLE
 Fix log race condition in rtt bindings

### DIFF
--- a/cmake/msvc.cmake
+++ b/cmake/msvc.cmake
@@ -9,9 +9,9 @@ add_definitions(
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4200")
 
 # Env variable hack as per http://cmake.3232098.n2.nabble.com/CMP0053-Unable-to-refer-to-ENV-PROGRAMFILES-X86-td7588994.html
-set(PROGRAMFILESX86 "PROGRAMFILES(X86)") 
+set(PROGRAMFILESX86 "PROGRAMFILES(X86)")
 
-set(PLATFORM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/win $ENV{${PROGRAMFILESX86}}/Nordic\ Semiconductor/nrf5x/bin/headers $ENV{PROGRAMFILES}/Nordic\ Semiconductor/nrf5x/bin/headers)
+set(PLATFORM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/win $ENV{${PROGRAMFILESX86}}/Nordic\ Semiconductor/nrf5x/bin/headers $ENV{ProgramW6432}/Nordic\ Semiconductor/nrf5x/bin/headers)
 
 file (GLOB PLATFORM_SOURCE_FILES
     "src/platform/win/*.cpp"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfjprog-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Javascript bindings for nrfjprog",
   "main": "index.js",
   "scripts": {

--- a/src/highlevel.cpp
+++ b/src/highlevel.cpp
@@ -99,6 +99,7 @@ NAN_METHOD(HighLevel::New)
 HighLevel::HighLevel()
 {
     keepDeviceOpen = false;
+    resetLog();
 }
 
 void HighLevel::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info,
@@ -119,7 +120,7 @@ void HighLevel::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info,
         return;
     }
 
-    logMessage.clear();
+    resetLog();
 
     auto argumentCount = 0;
     Baton *baton = nullptr;
@@ -180,13 +181,6 @@ void HighLevel::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info,
         Nan::ThrowError(message);
         return;
     }
-
-    log("===============================================\n");
-    log("Start of ");
-    log(baton->name.c_str());
-    log("\n");
-    log("===============================================\n");
-
 
     baton->executeFunction = execute;
     baton->returnFunction = ret;
@@ -339,6 +333,17 @@ void HighLevel::log(const char * msg)
     }
 
     logMessage.append(msg);
+}
+
+void HighLevel::resetLog()
+{
+    std::unique_lock<std::timed_mutex> lock (logMutex, std::defer_lock);
+
+    if(!lock.try_lock_for(std::chrono::seconds(10))) {
+        return;
+    }
+
+    logMessage.clear();
 }
 
 void HighLevel::progressCallback(const char * process)

--- a/src/highlevel.cpp
+++ b/src/highlevel.cpp
@@ -324,7 +324,13 @@ void HighLevel::ReturnFunction(uv_work_t *req)
     delete baton;
 }
 
-void HighLevel::log(const char * msg)
+
+void HighLevel::log(const char *msg)
+{
+    log(std::string(msg));
+}
+
+void HighLevel::log(const std::string& msg)
 {
     std::unique_lock<std::timed_mutex> lock (logMutex, std::defer_lock);
 

--- a/src/highlevel.h
+++ b/src/highlevel.h
@@ -106,6 +106,7 @@ private:
     static void init(v8::Local<v8::FunctionTemplate> tpl);
 
     static void log(const char * msg);
+    static void log(const std::string& msg);
     static void resetLog();
 
     static void progressCallback(const char * process);

--- a/src/highlevel.h
+++ b/src/highlevel.h
@@ -106,6 +106,7 @@ private:
     static void init(v8::Local<v8::FunctionTemplate> tpl);
 
     static void log(const char * msg);
+    static void resetLog();
 
     static void progressCallback(const char * process);
     static std::unique_ptr<Nan::Callback> jsProgressCallback;

--- a/src/rtt.cpp
+++ b/src/rtt.cpp
@@ -192,14 +192,6 @@ void RTT::CallFunction(Nan::NAN_METHOD_ARGS_TYPE info, rtt_parse_parameters_func
         return;
     }
 
-    log("===============================================\n");
-    log("Start of ");
-    log(baton->name.c_str());
-    log("\n");
-    log(baton->toString().c_str());
-    log("\n");
-    log("===============================================\n");
-
     baton->executeFunction = execute;
     baton->returnFunction = ret;
 

--- a/src/rtt.cpp
+++ b/src/rtt.cpp
@@ -259,6 +259,11 @@ void RTT::resetLog()
 
 void RTT::log(const char *msg)
 {
+    log(std::string(msg));
+}
+
+void RTT::log(const std::string& msg)
+{
     std::unique_lock<std::timed_mutex> lock (logMutex, std::defer_lock);
 
     if(!lock.try_lock_for(std::chrono::seconds(10))) {

--- a/src/rtt.h
+++ b/src/rtt.h
@@ -93,6 +93,7 @@ private:
     static void cleanup();
 
     static void log(const char * msg);
+    static void log(const std::string& msg);
     static void resetLog();
 
     static std::string logMessage;


### PR DESCRIPTION
This PR removes logging from the bindings side, without it PPK has been running stable for a day.
For a good measure the char* msg is wrapped in std::string to take ownership of the data by the new log() function eliminating the potential of the pointer being mishandled from the caller side.