### PR TITLE
Fix for module load issues on Windows with electron 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set_target_properties(${PROJECT_NAME}
 
 if(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DELAYLOAD:node.exe")
 elseif(APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework CoreFoundation")
     target_link_libraries(${PROJECT_NAME} "-framework IOKit")

--- a/src/platform/win/win_delay_load_hook.cpp
+++ b/src/platform/win/win_delay_load_hook.cpp
@@ -1,0 +1,38 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ *
+ * https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
+ */
+
+#ifdef _MSC_VER
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+      _stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+
+  m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
+
+#endif


### PR DESCRIPTION
This PR solves the module load failure on Windows with electron 4 following the example of https://github.com/NordicSemiconductor/pc-ble-driver-js/pull/216 
