### PR TITLE
Feature: modem uart dfu

### DIFF
--- a/doc/api.js
+++ b/doc/api.js
@@ -519,6 +519,24 @@ export function programDFU(serialNumber, filename, progressCallback, callback) {
  */
 export function programMcuBootDFU(serialNumber, filename, uart, timeout, progressCallback, callback) {}
 
+/**
+ * Async function to push a DFU update to a mcuboot based device in serial recovery mode.
+ * <br/>
+ *
+ * @example
+ * nrfjprogjs.programDFU(-1, "/some/path/nrf52832_abcd.hex", "COM1", 15000, function(progress) { console.log(progress) }, function(err) {
+  *      if (err) throw err;
+  * } );
+  *
+  * @param {integer} serialNumber Fake serial number, must be non zero
+  * @param {string} filename Filename of the <tt>.zip</tt> file containing the modem update
+  * @param {string} uart The connected device UART
+  * @param {integer} timeout Timeout in milliseconds. For DFU it must be more than 11000 because of response time when starting programming
+  * @param {Function} [progressCallback] Optional parameter for getting progress callbacks. It shall expect one parameter: ({@link module:pc-nrfjprog-js~Progress|Progress}).
+  * @param {Function} callback A callback function to handle the async response.
+  *   It shall expect one parameter: ({@link module:pc-nrfjprog-js~Error|Error}).
+  */
+ export function programModemUartDFU(serialNumber, filename, uart, timeout, progressCallback, callback) {}
 
 /**
  * Async function to read memory from the device and write the results into a file.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Javascript bindings for nrfjprog",
   "main": "index.js",
   "nrfjprog": {
-    "version": "10.5.0",
-    "jlink": "V654c"
+    "version": "10.6.0",
+    "jlink": "V660e"
   },
   "scripts": {
     "build": "node build.js",

--- a/src/highlevel.h
+++ b/src/highlevel.h
@@ -78,6 +78,8 @@ class HighLevel : public Nan::ObjectWrap
                                    // callback(error)
     static NAN_METHOD(ProgramMcuBootDFU); // Params: serialnumber, filename, callback(progress),
                                    // callback(error)
+    static NAN_METHOD(ProgramModemUartDFU); // Params: serialnumber, filename, callback(progress),
+                                   // callback(error)
 
     static NAN_METHOD(ReadToFile); // Params: serialnumber, filename, options {readram, readcode,
                                    // readuicr, readqspi}, callback(progress), callback(error)

--- a/src/highlevel_batons.h
+++ b/src/highlevel_batons.h
@@ -228,6 +228,18 @@ class ProgramMcuBootDFUBaton : public Baton
     uint32_t responseTimeout;
 };
 
+class ProgramModemUartDFUBaton : public Baton
+{
+  public:
+    ProgramModemUartDFUBaton()
+        : Baton("program", 0, true, MODEMUARTDFU_PROBE)
+    {}
+    std::string filename;
+    std::string uart;
+    uint32_t baudRate;
+    uint32_t responseTimeout;
+};
+
 class VerifyBaton : public BatonNeedsReset
 {
   public:

--- a/src/highlevel_common.h
+++ b/src/highlevel_common.h
@@ -48,7 +48,8 @@ typedef enum
 {
     MCUBOOT_PROBE,
     DFU_PROBE,
-    DEBUG_PROBE
+    DEBUG_PROBE,
+    MODEMUARTDFU_PROBE
 } probe_type_t;
 
 typedef enum


### PR DESCRIPTION
This PR updates nrfjprog libraries to 10.6.0 and uses the new `NRFJPROG_modemdfu_dfu_serial_init` to create the new probe type for modem programming.

After this change with a Thingy:91 you can do this:

```js
const api = require('pc-nrfjprog-js');

api.programMcuBootDFU(-1, 'nrfjprog/firmware/nrf9160_pca20035_firmware_upgrade_app_0.1.0.hex', 'COM-0', 115200, 12000, console.log, (err) => {
    if (err) {
        console.error(err);
        return;
    }
    api.programModemUartDFU(-1, 'mfw_nrf9160_1.1.1.zip', 'COM-1', 1000000, 12000, console.log, () => {
        console.log('done');
    });
});
...
```