### PR TITLE
fix linker errors when using module on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(APPLE)
 endif()
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-set(CMAKE_INSTALL_RPATH "nrfjprog")
+set(CMAKE_INSTALL_RPATH "nrfjprog" "@loader_path" "@loader_path/../../nrfjprog")
 
 # set(NRF_COMMAND_LINE_TOOLS_CMAKE_PACKAGE_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/nrfjprog/share)
 


### PR DESCRIPTION
Installing the module through npm and using it gives the following error message when loading

dlopen(/Users/swdev/Desktop/vscode-ncs-devtools/node_modules/pc-nrfjprog-js/build/Release/pc-nrfjprog-js.node, 1): Library not loaded @rpath/libhighlevelnrfjprog.dylib Referenced from: /Users/swdev/Desktop/vscode-ncs-devtools/node_modules/pc-nrfjprog-js/build/Release/pc-nrfjprog-js.node Reason: image not found

This happens because the linker does not look for libhighlevelnrfjprog.dylib where it is actually placed during release packaging.

Adding "@loader_path" to rpath allows the module to find libhighlevelnrfjprog.dylib when the module is packaged for release.
Adding "@loader_path/../../nrfjprog" allows the module to find libhighlevelnrfjprog.dylib when the module is built from source.