### PR TITLE
Update common.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,7 @@
 #define COMMON_H
 
 #include <map>
+#include <stdint.h>
 
 #define NAME_MAP_ENTRY(EXP)                                                                        \
     {                                                                                              \


### PR DESCRIPTION
Missing stdint include causes ninja build to fail since uint16_t is not defined